### PR TITLE
Output success after successful build

### DIFF
--- a/bin/build.js
+++ b/bin/build.js
@@ -122,7 +122,7 @@ function end(built){
 	}
 	if(error!=="") console.log(encode({'output':EOL+"ERRORS : "+EOL+EOL+error}));
 
-	if(built) console.log(encode({'filename':file}));
+	if(built) console.log(encode({'filename':file, 'output': "Success"+EOL}));
 	else console.log(encode({'filename':'error'}));
 }
 


### PR DESCRIPTION
Sometimes builds take a while and if you're only using the bottom console with build on save you are notified when an error occurs, but nothing happens when it's successful. 
This simply prints "Success" after the build commands