### PR TITLE
Edit typescript file without a project file

### DIFF
--- a/lib/system/Project.py
+++ b/lib/system/Project.py
@@ -8,7 +8,7 @@ import json
 
 from ..Utils import dirname, read_and_decode_json_file, get_kwargs, ST3
 
-
+errorSetting = {"ignore": False};
 # ------------------------------------- PROJECT SETTINGS ---------------------------------------- #
 
 class ProjectSettings(object):
@@ -75,6 +75,7 @@ class ProjectError(object):
 			self.messages.append(['Create a sublime project-file (one or multiple root files)','Click here and follow the instructions'])
 			self.messages.append(['Create a .sublimets project file (one root file only)','Click here and follow the instructions'])
 			self.messages.append(['I don\'t understand please show me the README file','Click here to open the README.md file'])
+			self.messages.append(['I don\'t want to create a typescript project now' ,'Ignore typescript project error for this session'])
 			self.window.show_quick_panel(self.messages,self._on_create_project)
 
 
@@ -105,6 +106,8 @@ class ProjectError(object):
 			pass
 		elif index == 3:
 			self.window.open_file(dirname+'/README.md')
+		elif index == 4:
+			errorSetting["ignore"] = True
 
 
 	# SET PROJECT NAME

--- a/lib/system/Settings.py
+++ b/lib/system/Settings.py
@@ -5,7 +5,7 @@ import sys
 import os
 
 from .Liste import get_root
-from .Project import ProjectSettings, ProjectError
+from .Project import ProjectSettings, ProjectError, errorSetting
 from ..Utils import read_and_decode_json_file, read_file, get_any_ts_view, fn2l, get_any_view_with_root
 
 # ----------------------------------------- CONSTANT ---------------------------------------- #
@@ -79,9 +79,12 @@ class Settings(object):
 				ProjectError(SUBLIME_TS,[config_data['root']+' is not a valid root file',config_file],config_file)
 				return None
 
+		if errorSetting["ignore"]:
+			return None
+
 		error_type = SUBLIME_PROJECT if has_project_settings else NO_PROJECT
 		path = sublime.active_window().project_file_name() if has_project_settings else None
-		message = ['No valid root file for this project inside your project file',path] if has_project_settings else ['You didn\'t create a project file, please create one:','Choose between the three possibilities bellow :']
+		message = ['No valid root file for this project inside your project file',path] if has_project_settings else ['You didn\'t create a project file, please create one:','Choose between the four possibilities bellow :']
 		ProjectError(error_type,message,path)
 		return None
 


### PR DESCRIPTION
Allows to open typescript file in sublime outside a project without being completely locked out by the create a new project window.

Adds an option to ignore no_project errors for the session. The variable is only saved in memory so the message will reappear if sublime is closed then reopen which is the desired scenario in my opinion.

![image](https://cloud.githubusercontent.com/assets/4157103/5870446/64afb35a-a29b-11e4-9a53-aac9c30a42f9.png)
